### PR TITLE
Ensure appointment foreign keys are tenant-scoped

### DIFF
--- a/packages/backend/prisma/migrations/20251206133233_init/migration.sql
+++ b/packages/backend/prisma/migrations/20251206133233_init/migration.sql
@@ -142,12 +142,6 @@ CREATE INDEX "appointments_barbershopId_date_idx" ON "appointments"("barbershopI
 CREATE INDEX "appointments_barbershopId_clientId_idx" ON "appointments"("barbershopId", "clientId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "professionals_barbershopId_id_key" ON "professionals"("barbershopId", "id");
-
--- CreateIndex
-CREATE UNIQUE INDEX "clients_barbershopId_id_key" ON "clients"("barbershopId", "id");
-
--- CreateIndex
 CREATE INDEX "transactions_barbershopId_date_idx" ON "transactions"("barbershopId", "date");
 
 -- CreateIndex
@@ -169,16 +163,16 @@ ALTER TABLE "services" ADD CONSTRAINT "services_barbershopId_fkey" FOREIGN KEY (
 ALTER TABLE "appointments" ADD CONSTRAINT "appointments_barbershopId_fkey" FOREIGN KEY ("barbershopId") REFERENCES "barbershops"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "appointments" ADD CONSTRAINT "appointments_barbershopId_professionalId_fkey" FOREIGN KEY ("barbershopId", "professionalId") REFERENCES "professionals"("barbershopId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_professionalId_fkey" FOREIGN KEY ("professionalId") REFERENCES "professionals"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "appointments" ADD CONSTRAINT "appointments_barbershopId_clientId_fkey" FOREIGN KEY ("barbershopId", "clientId") REFERENCES "clients"("barbershopId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "clients"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "appointments" ADD CONSTRAINT "appointments_serviceId_fkey" FOREIGN KEY ("serviceId") REFERENCES "services"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "appointments" ADD CONSTRAINT "appointments_barbershopId_createdById_fkey" FOREIGN KEY ("barbershopId", "createdById") REFERENCES "professionals"("barbershopId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "professionals"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "transactions" ADD CONSTRAINT "transactions_barbershopId_fkey" FOREIGN KEY ("barbershopId") REFERENCES "barbershops"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/migrations/20251210120000_tenant_scoped_appointment_fks/migration.sql
+++ b/packages/backend/prisma/migrations/20251210120000_tenant_scoped_appointment_fks/migration.sql
@@ -1,0 +1,23 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "professionals_barbershopId_id_key" ON "professionals"("barbershopId", "id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "clients_barbershopId_id_key" ON "clients"("barbershopId", "id");
+
+-- DropForeignKey
+ALTER TABLE "appointments" DROP CONSTRAINT "appointments_professionalId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "appointments" DROP CONSTRAINT "appointments_clientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "appointments" DROP CONSTRAINT "appointments_createdById_fkey";
+
+-- AddForeignKey
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_barbershopId_professionalId_fkey" FOREIGN KEY ("barbershopId", "professionalId") REFERENCES "professionals"("barbershopId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_barbershopId_clientId_fkey" FOREIGN KEY ("barbershopId", "clientId") REFERENCES "clients"("barbershopId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_barbershopId_createdById_fkey" FOREIGN KEY ("barbershopId", "createdById") REFERENCES "professionals"("barbershopId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary
- add composite unique indexes to scope professionals and clients to their barbershop
- update appointment foreign keys (including createdBy) to enforce tenant-scoped relationships

## Testing
- not run (schema-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693436abbd0083219ab2aa691244d130)